### PR TITLE
Chore: Make bash file executable by default

### DIFF
--- a/bin/production/deploy-production.sh
+++ b/bin/production/deploy-production.sh
@@ -1,5 +1,5 @@
-#! bin/bash
+#!/bin/bash
 
-# append --ask-vault-pass to this command if 
+# append --ask-vault-pass to this command if
 # using ansible-vault to encrypt ../group_vars/vault.yml
 ansible-playbook -i production site.yml -K --tags=deploy # --ask-vault-pass

--- a/bin/production/secure-production.sh
+++ b/bin/production/secure-production.sh
@@ -1,5 +1,5 @@
-#! bin/bash
+#!/bin/bash
 
-# append --ask-vault-pass to this command if 
+# append --ask-vault-pass to this command if
 # using ansible-vault to encrypt ../group_vars/vault.yml
 ansible-playbook -i production security.yml # --ask-vault-pass

--- a/bin/production/setup-production.sh
+++ b/bin/production/setup-production.sh
@@ -1,4 +1,4 @@
-#! bin/bash
+#!/bin/bash
 
 # append -K to this command if using a non-root sudo user
 # (i.e., if using with the security role)


### PR DESCRIPTION
- Set mode u+x for bash files
- use `/bin/bash` instead of `bin/bash`
See #1